### PR TITLE
Table header stays on top when scrolling through table

### DIFF
--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -7,6 +7,8 @@
       display: grid;
       grid-template-columns: 20em repeat(6, 1fr);
       grid-template-rows: 1fr;
+      position: sticky;
+      top: 0;
       padding-left: 1em;
       background: var(--table-head-bg) !important;
       font-family: var(--default-font);


### PR DESCRIPTION
The table header remains on top when scrolling through the table, as this makes it easier to use the site when there are many sites in the category.