### PR TITLE
Fix alignment of site names opposite their icons

### DIFF
--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -239,7 +239,7 @@
 
   .logo {
     margin-right: 0.7em;
-    height: 2.5em;
+    max-height: 2.5em;
     width: 2.5em;
     vertical-align: middle;
   }

--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -240,7 +240,7 @@
   .logo {
     margin-right: 0.7em;
     height: 2.5em;
-    max-width: 2.5em;
+    width: 2.5em;
     vertical-align: middle;
   }
 }


### PR DESCRIPTION
Fix the alignment of site names opposite their icons, as fixed width shouldn't be a problem for icons.

<details><summary>Before</summary>

![Screenshot 2022-12-07 at 17 46 39](https://user-images.githubusercontent.com/19418601/206210026-f6556ae0-b3db-4892-8dd2-a078604e9242.png)

</details>

<details><summary>After</summary>

![Screenshot 2022-12-07 at 17 47 46](https://user-images.githubusercontent.com/19418601/206210159-f99e71ac-46b2-423d-a8fb-5d224d68ebe9.png)

</details>