### PR TITLE
Simplify fix for search in dark theme

### DIFF
--- a/assets/css/navbar.scss
+++ b/assets/css/navbar.scss
@@ -71,5 +71,8 @@ nav {
     @media screen and (max-width: 445px) {
       left: 0 !important;
     }
+    @media (prefers-color-scheme: dark) {
+      color-scheme: light;
+    }
   }
 }

--- a/assets/css/search.scss
+++ b/assets/css/search.scss
@@ -34,9 +34,7 @@
     padding: .6rem;
     border: none;
     @media (prefers-color-scheme: dark) {
-      background-color: #fff;
-      color: #000;
-      caret-color: #000;
+      color-scheme: light;
     }
 
     &:focus {

--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -35,7 +35,10 @@
     line-height: 53px;
     grid-template-rows: 1fr;
     height: 4.4rem;
-
+    @media (prefers-color-scheme: dark) {
+      color-scheme: light;
+    }
+    
     /* replace with :has(.tfa) when supported */
     &.green {
       grid-template-columns: 20em repeat(6, 1fr);


### PR DESCRIPTION
Since there was also a problem with highlighted text in the search, and in order not to write new properties for this, it's easier to add `color-scheme: light` to solve the issue.