### PR TITLE
Adjust overflow on site names

### DIFF
--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -58,11 +58,6 @@
       overflow: clip;
     }
 
-    .name-wrapper {
-      display: inherit;
-      height: inherit;
-    }
-
     .name {
       grid-area: 1 / 1 / 2 / 2;
       line-height: 4.4rem;

--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -58,6 +58,11 @@
       overflow: clip;
     }
 
+    .name-wrapper {
+      display: inherit;
+      height: inherit;
+    }
+
     .name {
       grid-area: 1 / 1 / 2 / 2;
       line-height: 4.4rem;
@@ -236,6 +241,11 @@
   }
 }
 
+.name-wrapper {
+  display: inherit;
+  height: inherit;
+}
+
 .name {
   font-size: 18px;
   font-weight: 500;
@@ -286,6 +296,7 @@
       font-family: var(--default-font);
       font-weight: 300;
       grid-area: 1 / 1 / 2 / 2;
+      white-space: initial !important;
     }
 
     .note {

--- a/layouts/partials/table.html
+++ b/layouts/partials/table.html
@@ -32,7 +32,7 @@ Explanation:
   <!-- Display entry -->
   <div class="entry {{ if index $entry "tfa" }}green{{ else }}red{{ end }}" data-domain="{{- $entry.domain -}}">
 
-    <div>
+    <div class="name-wrapper">
         <a class="name" href="{{- with $entry.url -}}{{- . -}}{{- else -}}https://{{- $entry.domain -}}{{- end -}}"><img class="logo" loading="lazy" src="{{ $.icon_path }}{{- with $entry.img -}}{{- substr . 0 1 -}}/{{ . }}{{- else -}}{{- substr $entry.domain 0 1 -}}/{{- $entry.domain -}}.svg{{- end -}}" alt="">{{- htmlUnescape $name -}}</a>
       {{ if index $entry "notes" }}<i class="note bi bi-exclamation-diamond-fill" tabindex="0" data-bs-toggle="popover" data-bs-content="{{ $entry.notes }}"></i>{{ end }}
     </div>


### PR DESCRIPTION
Causes ellipse overflow css to trigger on desktop:
Before
![image](https://user-images.githubusercontent.com/20560218/209482403-c11cbea1-a4a7-4677-a5f1-4475f0a56029.png)
After
![image](https://user-images.githubusercontent.com/20560218/209482387-4b37e988-b7f9-46a4-806c-185bf445bb6b.png)

Wraps overflowing site names on mobile
Before
![image](https://user-images.githubusercontent.com/20560218/209482413-89fc7383-4db5-4113-a7c7-a7f83efee3c6.png)
After
![image](https://user-images.githubusercontent.com/20560218/209482430-49426ca2-5798-4838-b8d9-5f7571233d26.png)

