### PR TITLE
Fix text overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ After you've installed Hugo and Ruby, follow these steps to build the site local
 1. Install Ruby gems
    `bundle install`
 1. Fetch entries:
-   `./generate_entries.rb`
+   `./scripts/generate_entries.rb`
 1. Generate regional pages:
-   `./generate_regions.rb`
+   `./scripts/generate_regions.rb`
 1. Run Hugo locally:
    `hugo serve`  
    The site should then be reachable at [127.0.0.1:1313][localhost].
@@ -40,9 +40,9 @@ To publish your fork of this repo, follow these steps:
 1. Log in to your Cloudflare [Dashboard][cf_dash] and select Pages. Create a new project and select
    your fork as the source.
 2. When prompted for build configuration, enter the following:
-   * __Framework preset:__ `None`
-   * __Build command:__ `./scripts/build.sh`
-   * __Build output directory:__ `/public`
+   * **Framework preset:** `None`
+   * **Build command:** `./scripts/build.sh`
+   * **Build output directory:** `/public`
 
 ## Contributing
 
@@ -64,6 +64,7 @@ The general file structure is as follows:
 This project is licensed under GPLv3. For the entire license see [LICENSE](/LICENSE).
 
 Before you make changes to the code, please keep the following in mind:
+
 * The data is [licensed separately][data_license].
 * Attribution is required if you use this project as a template for your own website.
 * The initial contents of [LICENSE](/LICENSE) must still be included in distributions and forks but we allow (and

--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -278,7 +278,7 @@
   }
   .entry {
     padding: 1em;
-    display: inherit;
+    display: grid;
     border-bottom: var(--table-border);
 
     .title {

--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -61,6 +61,7 @@
     .name {
       grid-area: 1 / 1 / 2 / 2;
       line-height: 4.4rem;
+      padding: 0 .5em !important;
     }
 
     .note {
@@ -237,6 +238,8 @@
 }
 
 .name {
+  display: inline-block;
+  max-width: 100%;
   font-size: 18px;
   font-weight: 500;
   color: var(--table-text-color) !important;
@@ -275,22 +278,24 @@
   }
   .entry {
     padding: 1em;
-    display: grid;
-    grid-template-columns: 2fr;
-    grid-template-rows: auto;
-    grid-column-gap: 0;
-    grid-row-gap: .5em;
+    display: inherit;
     border-bottom: var(--table-border);
+
+    .title {
+      display: grid;
+      grid-auto-flow: column;
+    }
 
     .name {
       font-family: var(--default-font);
       font-weight: 300;
       grid-area: 1 / 1 / 2 / 2;
+      padding: .5em;
     }
 
     .note {
       float: right;
-      margin-right: 1rem;
+      margin-right: .5rem;
       font-size: 2em;
       line-height: 1.2em;
       color: #d03333;

--- a/layouts/partials/table.html
+++ b/layouts/partials/table.html
@@ -32,7 +32,7 @@ Explanation:
   <!-- Display entry -->
   <div class="entry {{ if index $entry "tfa" }}green{{ else }}red{{ end }}" data-domain="{{- $entry.domain -}}">
 
-    <div>
+    <div class="title">
         <a class="name" href="{{- with $entry.url -}}{{- . -}}{{- else -}}https://{{- $entry.domain -}}{{- end -}}"><img class="logo" loading="lazy" src="{{ $.icon_path }}{{- with $entry.img -}}{{- substr . 0 1 -}}/{{ . }}{{- else -}}{{- substr $entry.domain 0 1 -}}/{{- $entry.domain -}}.svg{{- end -}}" alt="">{{- htmlUnescape $name -}}</a>
       {{ if index $entry "notes" }}<i class="note bi bi-exclamation-diamond-fill" tabindex="0" data-bs-toggle="popover" data-bs-content="{{ $entry.notes }}"></i>{{ end }}
     </div>


### PR DESCRIPTION
# Summary

Note: Not sure why images aren't showing locally 

- Fix README local steps (scripts are in `scripts` folder)
- CSS fixes for text overflow on desktop and mobile

# Screenshots

## Desktop

Before: Text overflow doesn't show ellipsis
<img width="1317" alt="Screenshot 2022-12-26 at 23 08 17" src="https://user-images.githubusercontent.com/867840/209547727-c3a98535-96b3-4e75-aeae-7cd74a2e2108.png">

After: Text overflow shows ellipsis
<img width="1671" alt="Screenshot 2022-12-26 at 23 07 45" src="https://user-images.githubusercontent.com/867840/209547772-867a90ff-2b3c-497e-aae4-04b0ad699421.png">

## Mobile

Before: Text overflow causes the entry's width to also overflow, so buttons are cut off
<img width="384" alt="Screenshot 2022-12-26 at 23 08 30" src="https://user-images.githubusercontent.com/867840/209547872-956e9ca5-75e8-4300-b41f-6a96fc20e908.png">

After: Text overflow shows ellipsis and keep entry to display width
<img width="388" alt="Screenshot 2022-12-26 at 23 18 19" src="https://user-images.githubusercontent.com/867840/209548263-ddfc5501-18a7-470e-a228-629730883e90.png">
<img width="383" alt="Screenshot 2022-12-26 at 23 18 27" src="https://user-images.githubusercontent.com/867840/209548268-ef203c61-eca1-4ab3-bab3-12710d0e3b48.png">


