### PR TITLE
Add title to link to show on hover

### DIFF
--- a/layouts/partials/table.html
+++ b/layouts/partials/table.html
@@ -33,7 +33,7 @@ Explanation:
   <div class="entry {{ if index $entry "tfa" }}green{{ else }}red{{ end }}" data-domain="{{- $entry.domain -}}">
 
     <div class="title">
-        <a class="name" href="{{- with $entry.url -}}{{- . -}}{{- else -}}https://{{- $entry.domain -}}{{- end -}}"><img class="logo" loading="lazy" src="{{ $.icon_path }}{{- with $entry.img -}}{{- substr . 0 1 -}}/{{ . }}{{- else -}}{{- substr $entry.domain 0 1 -}}/{{- $entry.domain -}}.svg{{- end -}}" alt="">{{- htmlUnescape $name -}}</a>
+        <a class="name" href="{{- with $entry.url -}}{{- . -}}{{- else -}}https://{{- $entry.domain -}}{{- end -}}" title="{{- htmlUnescape $name -}}"><img class="logo" loading="lazy" src="{{ $.icon_path }}{{- with $entry.img -}}{{- substr . 0 1 -}}/{{ . }}{{- else -}}{{- substr $entry.domain 0 1 -}}/{{- $entry.domain -}}.svg{{- end -}}" alt="">{{- htmlUnescape $name -}}</a>
       {{ if index $entry "notes" }}<i class="note bi bi-exclamation-diamond-fill" tabindex="0" data-bs-toggle="popover" data-bs-content="{{ $entry.notes }}"></i>{{ end }}
     </div>
     {{- if index $entry "tfa" -}}


### PR DESCRIPTION
Add `title` to entry link so the title is shown on hover. This is useful for longer names that overflow and hidden by ellipsis
<img width="1368" alt="Screenshot 2022-12-27 at 11 02 48" src="https://user-images.githubusercontent.com/867840/209589439-8c0dcca4-c353-4281-9081-505917017b67.png">
