### PR TITLE
Fix misaligned table head

### DIFF
--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -9,7 +9,7 @@
       grid-template-rows: 1fr;
       position: sticky;
       top: 0;
-      padding-left: 1em;
+      padding-left: .5em;
       background: var(--table-head-bg) !important;
       font-family: var(--default-font);
       font-weight: 500;


### PR DESCRIPTION
Due to recent changes in the entry title layout, the table head became misaligned with the rest of the table. This PR fixes that.
![before](https://user-images.githubusercontent.com/3535780/213154498-c97640b6-9691-4e1f-9eac-741659f6bbed.png)
![after](https://user-images.githubusercontent.com/3535780/213154505-c14c3873-d6b1-409b-8a65-f3f6d15cfb64.png)
