### PR TITLE
Prevent PWA zoom

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no" />
+  <meta name="HandheldFriendly" content="true">
   {{- partial "base.meta" . -}}
   <title>{{- $.Site.Title -}}{{- block "title" . -}}{{- end -}}</title>
   {{- partial "base.stylesheet" . -}}


### PR DESCRIPTION
Currently, the viewport supports zooming inside Progressive Web Apps. This PR removes that ability making the PWA feel more like a native app. From my own experience, this shouldn't hinder zoom on a normal browser.

Zoom out in action:

https://user-images.githubusercontent.com/3535780/218342512-7a795b95-f471-4f8f-8ad6-992ac57b837b.mov

