### PR TITLE
Place category anchor on table instead of button

### DIFF
--- a/assets/js/table.js
+++ b/assets/js/table.js
@@ -51,6 +51,7 @@ function showCategory(category) {
   }).collapse("show");
   $(`.category-btn:not([href^="#${category}"])`).removeClass('active');
   $(button).addClass('active');
+  $('html, body').animate({ scrollTop: button.offset().top }, 'slow');
 }
 
 // Initialise popovers

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 {{- partial "base.navbar" . -}}
-<main class="container">
+<main class="container" role="main">
   {{- block "main" . -}}{{- end -}}
 </main>
 {{- partial "base.footer" . -}}

--- a/layouts/_default/tables.html
+++ b/layouts/_default/tables.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 {{ partial "search" }}
 
-<h3 id="categories-title" aria-hidden="true">Categories</h3>
+<h3 id="categories-title">Categories</h3>
 
 <div class="categories" aria-labelledby="categories-title">
   {{ partial "buttons" . }}

--- a/layouts/partials/base.footer.html
+++ b/layouts/partials/base.footer.html
@@ -1,4 +1,4 @@
-<footer>
+<footer role="contentinfo">
   <a class="back-to-top-link back-to-top-link-moved" href="#"><i class="bi bi-arrow-up-circle" aria-hidden="true"></i></a>
   <nav class="footer-inner">
     <a class="nav-item" href="/about">About</a>

--- a/layouts/partials/base.navbar.html
+++ b/layouts/partials/base.navbar.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg">
+<nav class="navbar navbar-expand-lg" role="navigation">
   <div class="container">
     <a class="nav-link" id="branding" href="{{ if eq .Layout "tables" }}/about/{{ else }} / {{ end }}">
       <ul class="icon">

--- a/layouts/partials/buttons.html
+++ b/layouts/partials/buttons.html
@@ -18,7 +18,7 @@
 
 {{ range $category_name := $category_names }}
 {{ $category := index $categories $category_name }}
-<div class="">
+<div>
   <button class="category-btn" href="#{{ $category_name }}" aria-controls="{{ $category_name }}"><span aria-hidden="true" class="category-icon">{{ htmlUnescape (index $category "icon") }}</span>
     <div>{{ index $category "title" }}</div>
   </button>

--- a/layouts/partials/buttons.html
+++ b/layouts/partials/buttons.html
@@ -19,7 +19,7 @@
 {{ range $category_name := $category_names }}
 {{ $category := index $categories $category_name }}
 <div class="">
-  <button id="{{ $category_name }}" class="category-btn" href="#{{ $category_name }}" aria-controls="{{ $category_name }}"><span aria-hidden="true" class="category-icon">{{ htmlUnescape (index $category "icon") }}</span>
+  <button class="category-btn" href="#{{ $category_name }}" aria-controls="{{ $category_name }}"><span aria-hidden="true" class="category-icon">{{ htmlUnescape (index $category "icon") }}</span>
     <div>{{ index $category "title" }}</div>
   </button>
 </div>

--- a/layouts/partials/table.html
+++ b/layouts/partials/table.html
@@ -27,9 +27,9 @@ Explanation:
        (not (in $region_excluded (printf "-%s" $a))))
 -}}
   <!-- Display entry -->
-  <div aria-label="{{ $entry.name }}" class="entry {{ if index $entry "tfa" }}green{{ else }}red{{ end }}" data-domain="{{- $entry.domain -}}">
+  <div role="row" class="entry {{ if index $entry "tfa" }}green{{ else }}red{{ end }}" data-domain="{{- $entry.domain -}}">
 
-    <div aria-hidden="true" class="title">
+    <div class="title">
         <a class="name" href="{{- with $entry.url -}}{{- . -}}{{- else -}}https://{{- $entry.domain -}}{{- end -}}" title="{{- htmlUnescape $entry.name -}}"><img class="logo" loading="lazy" src="{{ $.icon_path }}{{- with $entry.img -}}{{- substr . 0 1 -}}/{{ . }}{{- else -}}{{- substr $entry.domain 0 1 -}}/{{- $entry.domain -}}.svg{{- end -}}" aria-hidden="true" alt="">{{- htmlUnescape $entry.name -}}</a>
       {{ if index $entry "notes" }}<i class="note bi bi-exclamation-diamond-fill" tabindex="0" data-bs-toggle="popover" data-bs-content="{{ $entry.notes }}"></i>{{ end }}
     </div>

--- a/layouts/partials/tables.html
+++ b/layouts/partials/tables.html
@@ -1,6 +1,6 @@
 {{ $a := . }}
 {{- range $category_name, $category := site.Data.categories -}}
-<div id="{{ $category_name }}"  autofocus role="table" aria-selected="true" aria-labelledby="{{ $category_name }}" data-table="{{ $category_name }}" class="table collapse">
+<div id="{{ $category_name }}" role="table" aria-selected="true" aria-label="{{ index $category "title" }}" data-table="{{ $category_name }}" class="table collapse">
   <div aria-hidden="true" class="table-head">
     <div>{{ index $category "title" }}</div>
     <div>Docs</div>

--- a/layouts/partials/tables.html
+++ b/layouts/partials/tables.html
@@ -1,6 +1,6 @@
 {{ $a := . }}
 {{- range $category_name, $category := site.Data.categories -}}
-<div role="table" aria-selected="true" aria-labelledby="{{ $category_name }}" data-table="{{ $category_name }}" class="table collapse">
+<div id="{{ $category_name }}"  autofocus role="table" aria-selected="true" aria-labelledby="{{ $category_name }}" data-table="{{ $category_name }}" class="table collapse">
   <div aria-hidden="true" class="table-head">
     <div>{{ index $category "title" }}</div>
     <div>Docs</div>


### PR DESCRIPTION
Related to #37 and a recent Slack conversation.

Currently, the category button is focused on when opening a category. This is to not break the spacial awareness of the user.
This pull request moves the focus to the actual table and using JavaScript focuses on the category button.
The end result is visually nearly identical whilst at the same time allowing screen readers to focus on the actually desired content.

I also added `<section>` elements to better structure the content and allow for skipping unwanted data with a screen reader.