### PR TITLE
Redirect .well-known/security.txt to security reporting guide on GH

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,2 @@
 / /redirect 302
+/.well-known/security.txt https://github.com/2factorauth/twofactorauth/security/policy 301


### PR DESCRIPTION
`.well-known/security.txt` is a new-ish way of conveying how to report security vulnerabilities. As this information is already covered in the "Security Policy" on all our GitHub Repositories, I find it better to just link to that document instead.