### PR TITLE
Ignore incomplete search queries

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -16,14 +16,14 @@ $('.search').on('input', function () {
 })
 
 function sendSearch(query) {
-  $('.entry.hit').removeClass('hit');
-  if (query === undefined || query === "") {
+  if (query === undefined || query === "" || query.length < 3 || query.match('http(s)?:\/\/.*') || query.match('^2fa(:)?$')) {
     $('.category-btn').parent().show();
     $('.table').removeClass('show');
     $('.categories').removeClass('search-results');
     $('.entry:not(.hit)').show();
     $('.entries.hit').removeClass('hit');
   } else {
+    $('.entry.hit').removeClass('hit');
     // Hide category buttons
     $('.category-btn').parent().hide();
 


### PR DESCRIPTION
Temporarily disables searches containing any of the following:
*  Empty search queries.
* Searches with less than 3 characters. (Fixes #48)
* Searches with full URLs.
* 2FA searches without any specified 2FA method. (`/^2fa:$/`)

When Algolia InstantSearch is implemented it would be good to replace this PR change with some kind of message telling the user that the search is incomplete.