### PR TITLE
Switch to fillled icons & update BS Icons

### DIFF
--- a/data/categories.json
+++ b/data/categories.json
@@ -2,7 +2,7 @@
   "backup": {
     "name": "backup",
     "title": "Backup and Sync",
-    "icon": "&#xF6F9;"
+    "icon": "&#xF6F8;"
   },
   "banking": {
     "title": "Banking",
@@ -10,19 +10,19 @@
   },
   "betting": {
     "title": "Betting",
-    "icon": "&#xF5E7;"
+    "icon": "&#xF5E6;"
   },
   "cloud": {
     "title": "Cloud Computing",
-    "icon": "&#xF2C1;"
+    "icon": "&#xF29E;"
   },
   "communication": {
     "title": "Communication",
-    "icon": "&#xF24D;"
+    "icon": "&#xF24C;"
   },
   "creativity": {
     "title": "Creativity",
-    "icon": "&#xF4B1;"
+    "icon": "&#xF4B0;"
   },
   "crowdfunding": {
     "title": "Crowdfunding",
@@ -34,7 +34,7 @@
   },
   "developer": {
     "title": "Developer",
-    "icon": "&#xF2C6;"
+    "icon": "&#xF70E;"
   },
   "domains": {
     "title": "Domains",
@@ -46,11 +46,11 @@
   },
   "email": {
     "title": "Email",
-    "icon": "&#xF32F;"
+    "icon": "&#xF84B;"
   },
   "entertainment": {
     "title": "Entertainment",
-    "icon": "&#xF4F3;"
+    "icon": "&#xF4F2;"
   },
   "finance": {
     "title": "Finance",
@@ -74,11 +74,11 @@
   },
   "hosting": {
     "title": "Hosting/VPS",
-    "icon": "&#xF411;"
+    "icon": "&#xF410;"
   },
   "hotels": {
     "title": "Hotels and Accommodations",
-    "icon": "&#xF1DD;"
+    "icon": "&#xF87C;"
   },
   "identity": {
     "title": "Identity Management",
@@ -98,7 +98,7 @@
   },
   "marketing": {
     "title": "Marketing & Analytics",
-    "icon": "&#xF484;"
+    "icon": "&#xF483;"
   },
   "other": {
     "title": "Other",
@@ -110,7 +110,7 @@
   },
   "postal": {
     "title": "Post and Shipping",
-    "icon": "&#xF47C;"
+    "icon": "&#xF47D;"
   },
   "remote": {
     "title": "Remote Access",
@@ -118,15 +118,15 @@
   },
   "retail": {
     "title": "Retail",
-    "icon": "&#xF244;"
+    "icon": "&#xF23D;"
   },
   "security": {
     "title": "Security",
-    "icon": "&#xF538;"
+    "icon": "&#xF537;"
   },
   "social": {
     "title": "Social",
-    "icon": "&#xF4D0;"
+    "icon": "&#xF4CF;"
   },
   "task": {
     "title": "Task Management",
@@ -134,11 +134,11 @@
   },
   "tickets": {
     "title": "Tickets and Events",
-    "icon": "&#xF6CA;"
+    "icon": "&#xF6C9;"
   },
   "transport": {
     "title": "Transport",
-    "icon": "&#xF7CD;"
+    "icon": "&#xF7CC;"
   },
   "universities": {
     "title": "Universities",
@@ -146,7 +146,7 @@
   },
   "utilities": {
     "title": "Utilities",
-    "icon": "&#xF5C1;"
+    "icon": "&#xF5B4;"
   },
   "vpn": {
     "title": "VPN Providers",

--- a/layouts/partials/base.stylesheet.html
+++ b/layouts/partials/base.stylesheet.html
@@ -1,6 +1,6 @@
 <!-- External -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.2/css/bootstrap.min.css" integrity="sha512-CpIKUSyh9QX2+zSdfGP+eWLx23C8Dj9/XmHjZY2uDtfkdLGo0uY12jgcnkX9vXOgYajEKb/jiw67EYm+kBf+6g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.9.1/font/bootstrap-icons.min.css" integrity="sha512-5PV92qsds/16vyYIJo3T/As4m2d8b6oWYfoqV+vtizRB6KhF1F9kYzWzQmsO6T3z3QG2Xdhrx7FQ+5R1LiQdUA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.10.5/font/bootstrap-icons.min.css" integrity="sha512-ZnR2wlLbSbr8/c9AgLg3jQPAattCUImNsae6NHYnS9KrIwRdcY9DxFotXhNAKIKbAXlRnujIqUWoXXwqyFOeIQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icons/6.6.6/css/flag-icons.min.css" integrity="sha512-uvXdJud8WaOlQFjlz9B15Yy2Au/bMAvz79F7Xa6OakCl2jvQPdHD0hb3dEqZRdSwG4/sknePXlE7GiarwA/9Wg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
 <!-- Internal -->


### PR DESCRIPTION
Bootstrap recently published Bootstrap Icons v10.5. This new update introduces a few more icons, including a some new filled versions of the icons we're using as Category Icons. 