### PR TITLE
Deprecate API v1 & v2

### DIFF
--- a/content/api.md
+++ b/content/api.md
@@ -14,47 +14,47 @@ If you intend to query our JSON files often and with a lot of traffic, you may b
 
 If you only intent on using a specific dataset, like all sites supporting RFC-6238, we recommend that you use the URI which lists just that. See [URIs](#uris) for a list of available paths. The smaller the better.
 
-## Version 3
+## Version 3 {#version_3}
 
 ### URIs
 
-|Coverage|Unsigned File|PGP Signed File|
-|--------|-------------|-----------|
-|All sites|[/v3/all.json](https://api.2fa.directory/v3/all.json)|[/v3/all.json.sig](https://api.2fa.directory/v3/all.json.sig)|
-|All 2FA-supporting sites|[/v3/tfa.json](https://api.2fa.directory/v3/tfa.json)|[/v3/tfa.json.sig](https://api.2fa.directory/v3/tfa.json.sig)|
-|SMS|[/v3/sms.json](https://api.2fa.directory/v3/sms.json)|[/v3/sms.json.sig](https://api.2fa.directory/v3/sms.json.sig)|
-|Phone calls|[/v3/call.json](https://api.2fa.directory/v3/call.json)|[/v3/call.json.sig](https://api.2fa.directory/v3/call.json.sig)|
-|Email 2FA|[/v3/email.json](https://api.2fa.directory/v3/email.json)|[/v3/email.json.sig](https://api.2fa.directory/v3/email.json.sig)|
-|non-U2F hardware 2FA tokens|[/v3/custom-hardware.json](https://api.2fa.directory/v3/custom-hardware.json)|[/v3/custom-hardware.json.sig](https://api.2fa.directory/v3/custom-hardware.json.sig)|
-|U2F hardware tokens|[/v3/u2f.json](https://api.2fa.directory/v3/u2f.json)|[/v3/u2f.json.sig](https://api.2fa.directory/v3/u2f.json.sig)|
-|RFC-6238 (TOTP)|[/v3/totp.json](https://api.2fa.directory/v3/totp.json)|[/v3/totp.json.sig](https://api.2fa.directory/v3/totp.json.sig)|
-|non-RFC-6238 software 2FA|[/v3/custom-software.json](https://api.2fa.directory/v3/custom-software.json)|[/v3/custom-software.json.sig](https://api.2fa.directory/v3/custom-software.json.sig)|
+| Coverage                    | Unsigned File                                                                 | PGP Signed File                                                                       |
+|-----------------------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| All sites                   | [/v3/all.json](https://api.2fa.directory/v3/all.json)                         | [/v3/all.json.sig](https://api.2fa.directory/v3/all.json.sig)                         |
+| All 2FA-supporting sites    | [/v3/tfa.json](https://api.2fa.directory/v3/tfa.json)                         | [/v3/tfa.json.sig](https://api.2fa.directory/v3/tfa.json.sig)                         |
+| SMS                         | [/v3/sms.json](https://api.2fa.directory/v3/sms.json)                         | [/v3/sms.json.sig](https://api.2fa.directory/v3/sms.json.sig)                         |
+| Phone calls                 | [/v3/call.json](https://api.2fa.directory/v3/call.json)                       | [/v3/call.json.sig](https://api.2fa.directory/v3/call.json.sig)                       |
+| Email 2FA                   | [/v3/email.json](https://api.2fa.directory/v3/email.json)                     | [/v3/email.json.sig](https://api.2fa.directory/v3/email.json.sig)                     |
+| non-U2F hardware 2FA tokens | [/v3/custom-hardware.json](https://api.2fa.directory/v3/custom-hardware.json) | [/v3/custom-hardware.json.sig](https://api.2fa.directory/v3/custom-hardware.json.sig) |
+| U2F hardware tokens         | [/v3/u2f.json](https://api.2fa.directory/v3/u2f.json)                         | [/v3/u2f.json.sig](https://api.2fa.directory/v3/u2f.json.sig)                         |
+| RFC-6238 (TOTP)             | [/v3/totp.json](https://api.2fa.directory/v3/totp.json)                       | [/v3/totp.json.sig](https://api.2fa.directory/v3/totp.json.sig)                       |
+| non-RFC-6238 software 2FA   | [/v3/custom-software.json](https://api.2fa.directory/v3/custom-software.json) | [/v3/custom-software.json.sig](https://api.2fa.directory/v3/custom-software.json.sig) |
 
 ### Elements
 
-|Key|Value Type|Always Defined|Description|
-|---|-----|:------------:|-----------|
-|domain|<define>FQDN</define>|:heavy_check_mark:|The domain name of the service|
-|img|String||Image name used. If this is not defined, the image name is `domain`.svg|
-|url|URL||URL of the site. If this is not defined, the url is https://`domain`|
-|tfa|Array\<String>||Array containing all supported 2FA methods|
-|documentation|URL||URL to documentation page|
-|recovery|URL||URL to recovery documentation page|
-|notes|String||Text describing any discrepancies in the 2FA implementation|
-|contact|Object||Object containing contact details. See table below for elements|
-|regions|Array\<String>||Array containing ISO 3166-1 country codes of the regions in which the site is available. If the site is available everywhere apart from a specific region, that region will be prefixed by a `-` symbol|
-|additional-domains|Array\<hostname>||Array of domains that the site exists at in addition to the main domain listed in the `domain` field.|
-|custom-(software\|hardware)|Array\<String>||Array of custom software/hardware methods that the site supports. Only present if the `tfa` element contains one of these 2FA types|
-|keywords|Array\<String>|:heavy_check_mark:|Array of categories to which the site belongs|
+| Key                         | Value Type            |   Always Defined   | Description                                                                                                                                                                                             |
+|-----------------------------|-----------------------|:------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| domain                      | <define>FQDN</define> | :heavy_check_mark: | The domain name of the service                                                                                                                                                                          |
+| img                         | String                |                    | Image name used. If this is not defined, the image name is `domain`.svg                                                                                                                                 |
+| url                         | URL                   |                    | URL of the site. If this is not defined, the url is https://`domain`                                                                                                                                    |
+| tfa                         | Array\<String>        |                    | Array containing all supported 2FA methods                                                                                                                                                              |
+| documentation               | URL                   |                    | URL to documentation page                                                                                                                                                                               |
+| recovery                    | URL                   |                    | URL to recovery documentation page                                                                                                                                                                      |
+| notes                       | String                |                    | Text describing any discrepancies in the 2FA implementation                                                                                                                                             |
+| contact                     | Object                |                    | Object containing contact details. See table below for elements                                                                                                                                         |
+| regions                     | Array\<String>        |                    | Array containing ISO 3166-1 country codes of the regions in which the site is available. If the site is available everywhere apart from a specific region, that region will be prefixed by a `-` symbol |
+| additional-domains          | Array\<hostname>      |                    | Array of domains that the site exists at in addition to the main domain listed in the `domain` field.                                                                                                   |
+| custom-(software\|hardware) | Array\<String>        |                    | Array of custom software/hardware methods that the site supports. Only present if the `tfa` element contains one of these 2FA types                                                                     |
+| keywords                    | Array\<String>        | :heavy_check_mark: | Array of categories to which the site belongs                                                                                                                                                           |
 
 #### Contact Object Elements
-|Key|Value|Always Defined|Description|
-|---|-----|:------------:|-----------|
-|twitter|String||Twitter handle|
-|facebook|String||Facebook page name|
-|email|String||Email address to support|
-|form|String||Support contact form|
-|language|String||Lowercase ISO 639-1 language code for the site if it is not in English|
+| Key      | Value  | Always Defined | Description                                                            |
+|----------|--------|:--------------:|------------------------------------------------------------------------|
+| twitter  | String |                | Twitter handle                                                         |
+| facebook | String |                | Facebook page name                                                     |
+| email    | String |                | Email address to support                                               |
+| form     | String |                | Support contact form                                                   |
+| language | String |                | Lowercase ISO 639-1 language code for the site if it is not in English |
 
 ### Example website with 2FA enabled
 
@@ -112,34 +112,36 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 ]
 ```
 
-## Version 2 (Deprecated) :warning:
+## Version 2 {#version_2}
+
+{{% warning title="⚠️ Deprecated" %}} API version 2 will be sunset on 2023-08-01. Please update your code to use [version 3](#version_3) before then.{{% /warning %}}
 
 ### URIs
 
-|Coverage|Unsigned File|PGP Signed File|
-|--------|-------------|-----------|
-|All sites|[/v2/all.json](https://api.2fa.directory/v2/all.json)|[v2/all.json.sig](https://api.2fa.directory/v2/all.json.sig)|
-|All 2FA-supporting sites|[/v2/tfa.json](https://api.2fa.directory/v2/tfa.json)|[v2/tfa.json.sig](https://api.2fa.directory/v2/tfa.json.sig)|
-|SMS|[/v2/sms.json](https://api.2fa.directory/v2/sms.json)|[v2/sms.json.sig](https://api.2fa.directory/v2/sms.json.sig)|
-|Phone calls|[/v2/phone.json](https://api.2fa.directory/v2/phone.json)|[v2/phone.json.sig](https://api.2fa.directory/v2/phone.json.sig)|
-|Email 2FA|[/v2/email.json](https://api.2fa.directory/v2/email.json)|[v2/email.json.sig](https://api.2fa.directory/v2/email.json.sig)|
-|non-U2F hardware 2FA tokens|[/v2/hardware.json](https://api.2fa.directory/v2/hardware.json)|[v2/hardware.json.sig](https://api.2fa.directory/v2/hardware.json.sig)|
-|U2F hardware tokens|[/v2/u2f.json](https://api.2fa.directory/v2/u2f.json)|[v2/u2f.json.sig](https://api.2fa.directory/v2/u2f.json.sig)|
-|RFC-6238 (TOTP)|[/v2/totp.json](https://api.2fa.directory/v2/totp.json)|[v2/totp.json.sig](https://api.2fa.directory/v2/totp.json.sig)|
-|non-RFC-6238 software 2FA|[/v2/proprietary.json](https://api.2fa.directory/v2/proprietary.json)|[v2/proprietary.json.sig](https://api.2fa.directory/v2/proprietary.json.sig)|
+| Coverage                    | Unsigned File                                                         | PGP Signed File                                                              |
+|-----------------------------|-----------------------------------------------------------------------|------------------------------------------------------------------------------|
+| All sites                   | [/v2/all.json](https://api.2fa.directory/v2/all.json)                 | [v2/all.json.sig](https://api.2fa.directory/v2/all.json.sig)                 |
+| All 2FA-supporting sites    | [/v2/tfa.json](https://api.2fa.directory/v2/tfa.json)                 | [v2/tfa.json.sig](https://api.2fa.directory/v2/tfa.json.sig)                 |
+| SMS                         | [/v2/sms.json](https://api.2fa.directory/v2/sms.json)                 | [v2/sms.json.sig](https://api.2fa.directory/v2/sms.json.sig)                 |
+| Phone calls                 | [/v2/phone.json](https://api.2fa.directory/v2/phone.json)             | [v2/phone.json.sig](https://api.2fa.directory/v2/phone.json.sig)             |
+| Email 2FA                   | [/v2/email.json](https://api.2fa.directory/v2/email.json)             | [v2/email.json.sig](https://api.2fa.directory/v2/email.json.sig)             |
+| non-U2F hardware 2FA tokens | [/v2/hardware.json](https://api.2fa.directory/v2/hardware.json)       | [v2/hardware.json.sig](https://api.2fa.directory/v2/hardware.json.sig)       |
+| U2F hardware tokens         | [/v2/u2f.json](https://api.2fa.directory/v2/u2f.json)                 | [v2/u2f.json.sig](https://api.2fa.directory/v2/u2f.json.sig)                 |
+| RFC-6238 (TOTP)             | [/v2/totp.json](https://api.2fa.directory/v2/totp.json)               | [v2/totp.json.sig](https://api.2fa.directory/v2/totp.json.sig)               |
+| non-RFC-6238 software 2FA   | [/v2/proprietary.json](https://api.2fa.directory/v2/proprietary.json) | [v2/proprietary.json.sig](https://api.2fa.directory/v2/proprietary.json.sig) |
 
 ### Elements
 
-|Key|Value Type|Always Defined|Description|
-|---|-----|:------------:|-----------|
-|url|URL|:heavy_check_mark:|URL to the main page of the site/service|
-|img|String|:heavy_check_mark:|Image name used|
-|tfa|Array\<String>||Array containing all supported 2FA methods|
-|doc|URL||URL to documentation page|
-|exception|String||Text describing any discrepancies in the 2FA implementation|
-|twitter|String||Twitter handle|
-|facebook|String||Facebook page name|
-|email_address|String||Email address to support|
+| Key           | Value Type     |   Always Defined   | Description                                                 |
+|---------------|----------------|:------------------:|-------------------------------------------------------------|
+| url           | URL            | :heavy_check_mark: | URL to the main page of the site/service                    |
+| img           | String         | :heavy_check_mark: | Image name used                                             |
+| tfa           | Array\<String> |                    | Array containing all supported 2FA methods                  |
+| doc           | URL            |                    | URL to documentation page                                   |
+| exception     | String         |                    | Text describing any discrepancies in the 2FA implementation |
+| twitter       | String         |                    | Twitter handle                                              |
+| facebook      | String         |                    | Facebook page name                                          |
+| email_address | String         |                    | Email address to support                                    |
 
 ### Example website with 2FA enabled
 
@@ -180,7 +182,9 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 }
 ```
 
-## Version 1 (Deprecated) :warning:
+## Version 1 {#version_1}
+
+{{% warning title="⚠️ Deprecated" %}}API version 1 will be sunset on 2023-07-01. Please update your code to use [version 3](#version_3) before then.{{% /warning %}}
 
 ### URIs
 
@@ -222,27 +226,3 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 ```
 
 ### Example website with 2FA enabled
-
-```JSON
-{
-  "Category name": {
-    "Website name": {
-      "name": "Website name",
-      "url": "https://example.com/",
-      "img": "example.png",
-      "tfa": true,
-      "sms": true,
-      "phone": true,
-      "email": true,
-      "software": true,
-      "hardware": true,
-      "doc": "https://example.com/documention/enable-2fa/",
-      "exceptions": {
-        "text": "Text describing any discrepancies in the 2FA implementation."
-      }
-    }   
-  }
-}
-```
-
-If a website only supports some 2FA methods, the unsupported 2FA methods won't be listed (i.e. NULL).

--- a/content/api.md
+++ b/content/api.md
@@ -226,3 +226,27 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 ```
 
 ### Example website with 2FA enabled
+
+```JSON
+{
+  "Category name": {
+    "Website name": {
+      "name": "Website name",
+      "url": "https://example.com/",
+      "img": "example.png",
+      "tfa": true,
+      "sms": true,
+      "phone": true,
+      "email": true,
+      "software": true,
+      "hardware": true,
+      "doc": "https://example.com/documention/enable-2fa/",
+      "exceptions": {
+        "text": "Text describing any discrepancies in the 2FA implementation."
+      }
+    }   
+  }
+}
+```
+
+If a website only supports some 2FA methods, the unsupported 2FA methods won't be listed (i.e. NULL).

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,0 +1,5 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+<div class="alert alert-warning }}" style="width: max-content">
+  <h4 class="alert-heading" style="margin-top:0;">{{ .Get "title" | safeHTML }}</h4>
+  {{ .Inner | safeHTML }}
+</div>


### PR DESCRIPTION
Our API versions 1 & 2 have been deprecated for several years and receive very little traffic.
I think it would be good to finally sunset them.

I'm unaware of anyone still using version 1 so a warning of one month would suffice.
For version 2, a +2-month grace period seems reasonable to me.

Attaching the notices below:

![Screenshot 2023-05-28 at 00-23-53 2FA Directory](https://github.com/2factorauth/frontend/assets/3535780/cb7fe63f-df52-451c-a3b1-1dbf7d8ae102)
![Screenshot 2023-05-28 at 00-24-00 2FA Directory](https://github.com/2factorauth/frontend/assets/3535780/83479177-cf76-476e-a0b4-58af7ae5cec4)
