### PR TITLE
Update markdown files & remove report-uri usage

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -3,4 +3,4 @@ layout: about
 ---
 2factorauth is a non-profit organization registered in Sweden with members across the globe.  
 Our mission is to be an independent source of information on which services support MFA/2FA and help consumers demand MFA/2FA on the services that currently don't.
-Together we're able to get more platforms to #Support2FA.
+Together, we're able to get more platforms to #Support2FA.

--- a/content/api.md
+++ b/content/api.md
@@ -4,15 +4,15 @@ title: API usage
 ---
 ## Introduction
 
-The data collected for the 2fa.directory website is also available as JSON files in order to enable developers to use it in their own programs. It is recommended to use the API with the highest version number, since older versions might not include all available information.
+The data collected for the [2FA Directory](https://2fa.directory) website is also available as JSON files to enable developers to use it in their programs. The API with the highest version number is recommended since older versions might not include all available information.
 
 ### Caching
 
-If you intend to query our JSON files often and with a lot of traffic, you may be blocked by Cloudflare, our reverse proxy provider. We therefore recommend that you cache the files locally for any large traffic cases.
+If you intend to query our JSON files often and with a lot of traffic, you may be blocked by Cloudflare, our reverse proxy provider. We therefore recommend that you cache the files locally for any significant traffic cases.
 
 ### Avoid downloading unnecessary data
 
-If you only intent on using a specific dataset, like all sites supporting RFC-6238, we recommend that you use the URI which lists just that. See [URIs](#uris) for a list of available paths. The smaller the better.
+If you only intend to use a specific dataset, like all sites supporting RFC-6238, we recommend using the URI which lists _just_ that. See [URIs](#uris) for available paths. The smaller, the better.
 
 ## Version 3 {#v3}
 
@@ -114,8 +114,8 @@ If you only intent on using a specific dataset, like all sites supporting RFC-62
 
 ## Version 2 {#v2}
 
-API version 2 is no longer available. If you use this version, please upgrade to [version 3](#v3).
+API version 2 is no longer available. Please upgrade to [version 3](#v3) if you use this version.
 
 ## Version 1 {#v1}
 
-API version 1 is no longer available. If you use this version, please upgrade to [version 3](#v3).
+API version 1 is no longer available. Please upgrade to [version 3](#v3) if you use this version.

--- a/content/bots.md
+++ b/content/bots.md
@@ -4,7 +4,7 @@ title: 2factorauth Web Bots
 aliases: /bot
 ---
 To validate user contributions, we use scripts or "bots."  
-These scripts only make requests to your website when someone tries to edit data about your site on the 2FA Directory.   
+These scripts only make requests to your website when someone tries to edit data about your site on 2FA Directory.   
 As a result, you will only receive a couple of requests each year. We would be very thankful if you didn't block these HTTP requests.
 
 ## User agents:

--- a/content/bots.md
+++ b/content/bots.md
@@ -3,9 +3,9 @@ layout: page
 title: 2factorauth Web Bots
 aliases: /bot
 ---
-In order to validate user contributions we use scripts or "bots".  
-These scripts only make requests to your website when someone tries to edit data about your site on 2fa.directory.   
-As a result you will most likely only receive a couple of requests each year. We would be very thankful if you didn't block these HTTP requests.
+To validate user contributions, we use scripts or "bots."  
+These scripts only make requests to your website when someone tries to edit data about your site on the 2FA Directory.   
+As a result, you will only receive a couple of requests each year. We would be very thankful if you didn't block these HTTP requests.
 
 ## User agents:
 
@@ -18,7 +18,7 @@ As a result you will most likely only receive a couple of requests each year. We
 
 ## robots.txt
 
-Since each script only makes one request per website, the same number as if we would have fetched any robots.txt file, we have opted to not comply with robots.txt files.
+Since each script only makes one request per website, the same number as if we would have fetched any robots.txt file, we have opted not to comply with robots.txt files.
 
 [validate-urls]: https://github.com/2factorauth/twofactorauth/blob/master/tests/validate-urls.rb
 [language-codes]: https://github.com/2factorauth/twofactorauth/blob/master/tests/language-codes.rb

--- a/content/companies.md
+++ b/content/companies.md
@@ -14,7 +14,7 @@ If you currently do not support two-factor authentication, the listing serves as
 ### Edit a listing
 If the data about a service is inaccurate, you can create an [issue][issue] or [pull request][pr] on GitHub to update it.
 
-## Takedown requests / DMCA[api.md](api.md)
+## Takedown requests / DMCA
 As __2factorauth__ is registered in Sweden, The Digital Millennium Copyright Act does not apply to the [2FA Directory][directory], and thus, DMCA requests will be ignored.
 All the information on the [2FA Directory][directory] is public information compliant with _fair use_. We believe consumers should be able to compare services to find the alternative that best fits them; We therefore do not remove listings.
 

--- a/content/companies.md
+++ b/content/companies.md
@@ -6,27 +6,29 @@ title: Information to companies
 The directory is run by the non-profit organization __2factorauth__, registered in Sweden.
 
 ## The content
-All our content is crowdsourced and moderated by __2factorauth__. If a person requests to list a new service and said service meets our [listing criteria][criteria] and [guidelines][guidelines], it gets published to the directory.
+All our content is crowdsourced and moderated by __2factorauth__. If a person requests to list a new service that meets our [listing criteria][criteria] and [guidelines][guidelines], it gets published in the directory.
 
-If you find your service listed here it most likely means one of your own users have requested it. If you already provide two factor authentication, the list will function as free promotion for your service.  
-If you currently do not support two factor authentication, the listing functions as a reminder that your customers think this is an important thing for you to provide. 
+If you find your service listed here, one of your users has requested it. If you already provide two-factor authentication, the list will function as a free promotion for your service.    
+If you currently do not support two-factor authentication, the listing serves as a reminder that your customers think this is important for you to provide.
 
 ### Edit a listing
-If the data about a service is inaccurate you can create an [issue][issue] or [pull request][pr] on GitHub to update it.
+If the data about a service is inaccurate, you can create an [issue][issue] or [pull request][pr] on GitHub to update it.
 
-## Takedown requests / DMCA
-As __2factorauth__ is registered in Sweden, The Digital Millennium Copyright Act does not apply to 2fa.directory and thus DMCA requests will be ignored.
-All the information on 2fa.directory is both public information and compliant with _fair use_. We believe consumers should be able to compare services to find the alternative that best fits them; We therefore do not remove listings.
+## Takedown requests / DMCA[api.md](api.md)
+As __2factorauth__ is registered in Sweden, The Digital Millennium Copyright Act does not apply to the [2FA Directory][directory], and thus, DMCA requests will be ignored.
+All the information on the [2FA Directory][directory] is public information compliant with _fair use_. We believe consumers should be able to compare services to find the alternative that best fits them; We therefore do not remove listings.
 
-If you have further questions you may contact us by [email](mailto:legal@2fa.directory) or by post:
-```
-2factorauth,
-C/O Postia 1006,
-214 13 Malmö,
-Sweden
-```
+If you have questions, you may contact us by [email](mailto:legal@2fa.directory) or by mail:
+<address>
+<b>2factorauth</b><br>
+C/O Infostig<br>
+Notvarpsgränd 3<br> 
+116 66 Stockholm<br>
+SWEDEN
+</address>
 
 [guidelines]:https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md#guidelines
 [criteria]:https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md#site-criteria
 [issue]:https://github.com/2factorauth/twofactorauth/issues/new/choose
 [pr]:https://github.com/2factorauth/twofactorauth/blob/master/CONTRIBUTING.md
+[directory]:https://2fa.directory/

--- a/content/companies.md
+++ b/content/companies.md
@@ -15,7 +15,7 @@ If you currently do not support two-factor authentication, the listing serves as
 If the data about a service is inaccurate, you can create an [issue][issue] or [pull request][pr] on GitHub to update it.
 
 ## Takedown requests / DMCA
-As __2factorauth__ is registered in Sweden, The Digital Millennium Copyright Act does not apply to the [2FA Directory][directory], and thus, DMCA requests will be ignored.
+As __2factorauth__ is registered in Sweden, the Digital Millennium Copyright Act does not apply to the [2FA Directory][directory], and thus, DMCA requests will be ignored.
 All the information on the [2FA Directory][directory] is public information compliant with _fair use_. We believe consumers should be able to compare services to find the alternative that best fits them; We therefore do not remove listings.
 
 If you have questions, you may contact us by [email](mailto:legal@2fa.directory) or by mail:

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -2,36 +2,25 @@
 layout: page
 title: Privacy Policy
 ---
-We believe security and privacy goes hand-in-hand and so to protect our users we don't keep any records of who visits our website.  
-We do however rely on some third-parties, through EU GDPR Article 28, to host and deliver the website content and these third-parties may keep records they deem necessary for the continuous operation of their services.
+Security and privacy go hand-in-hand, and so to protect our users, we don't keep any records of who visits our website or in any other way uses our services.
+However, we rely on some sub-processors, through EU GDPR Article 28, to host and deliver the website content, and these third parties may keep records they deem necessary for the continuous operation of their services.
+2factorauth uses the following third-party entities as sub-processors for the activities listed below:
 
-Below you'll find a list of the third parties we rely on, along with their privacy policies.
+| Sub-Processor             | Activity                           |   Location    |
+|---------------------------|------------------------------------|:-------------:|
+| GitHub Inc.               | Hosting & Version Control System   | United States |
+| Cloudflare Inc.           | Hosting & Content Delivery Network | United States |
+| Zoho Corporation Pvt. Ltd | Email                              |      EEA      |
 
-| Company         |       Services       |                     Policies                      | Country of Origin |
-|-----------------|:--------------------:|:-------------------------------------------------:|:-----------------:|
-| GitHub Inc.     |    Hosting & VCS     |               [Privacy][github_pp]                |        US         |
-| Cloudflare Inc. |         CDN          | [Privacy][cloudflare_pp], [GDPR][cloudflare_gdpr] |        US         |
-| Report-URI Ltd. | CSP Report Collector | [Privacy][report_uri_pp], [DPA][report_uri_gdpr]  |        GB         |
+As a user, you can review our data processing agreements with each sub-processor. Contact [privacy@2fa.directory](mailto:privacy@2fa.directory) to receive a copy.
 
 ## GDPR Requests
 
-As we collect no Personally Identifiable Information (PII), we are unable to comply with GDPR Article 15-17 requests to obtain, edit or delete PII.  
-Should you wish to exercise any of these rights on the third-party dependencies listed above, we recommend you contact them directly.
+If you wish to exercise your right to delete, modify, copy, or transfer your Personally Identifiable Information (PII) stored by the sub-processors listed above, contact [privacy@2fa.directory](mailto:privacy@2fa.directory) or the sub-processor(s) directly.
+Please note that, as we neither have access to the data nor the right to represent you without your explicit permission, Should you choose to send your request through us, the sub-processor(s) may require additional written confirmation from you before processing your request.
+Requests sent through us to our sub-processor(s) may also be limited to the data collection done by the entity as our sub-processors, and the company may retain further PII outside the scope as our sub-processor(s).
 
-## GDPR Complaints
+If you have filed a GDPR request with us and find the response unsatisfactory, you may file a complaint with your country's governing [data protection authority][dpa].
 
-If you wish to make a GDPR complaint you may do so by mail.
-```
-2factorauth,
-C/O Postia 1006,
-214 13 Malmö,
-Sweden
-```
-
-If the response is not satisfactory, you may choose to contact the governing [data protection authority](https://ec.europa.eu/justice/article-29/structure/data-protection-authorities/index_en.htm) of your country.
-
-[cloudflare_gdpr]: https://www.cloudflare.com/trust-hub/gdpr/
-[cloudflare_pp]: https://www.cloudflare.com/privacypolicy/
-[github_pp]: https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement
-[report_uri_gdpr]: https://cdn.report-uri.com/pdf/Report%20URI%20-%20DPA%20(2v0).pdf
-[report_uri_pp]: https://report-uri.com/home/privacy_policy
+[dpa]: https://ec.europa.eu/justice/article-29/structure/data-protection-authorities/index_en.htm
+[directory]: https://2fa.directory

--- a/static/_headers
+++ b/static/_headers
@@ -6,4 +6,4 @@
 
 /about/
   ! Content-Security-Policy
-  Content-Security-Policy: script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://cdnjs.cloudflare.com; img-src 'self' https://avatars.githubusercontent.com; font-src https://cdnjs.cloudflare.com; block-all-mixed-content; report-uri https://2factorauth.report-uri.com/r/d/csp/enforce;
+  Content-Security-Policy: script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' https://cdnjs.cloudflare.com; img-src 'self' https://avatars.githubusercontent.com; font-src https://cdnjs.cloudflare.com; block-all-mixed-content;


### PR DESCRIPTION
In this PR, I've:
* Made grammatical changes to the markdown files
* Rephrased the privacy page to better adhere to the GDPR regulations.
*  Changed the post address for the org in [/companies](https://2fa.directory/companies/).
* Removed [Report URI](https://report-uri.com/) from the CSP as their free tier doesn't offer the contracts required for GDPR compliance.